### PR TITLE
Error in installing Update worker.go

### DIFF
--- a/pkg/scanner/worker.go
+++ b/pkg/scanner/worker.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 	"strings"
-	"sync"
+	//"sync"
 	"time"
 
 	


### PR DESCRIPTION
 go build -o hx-hawks main.go
# github.com/nxneeraj/hx-hawks/pkg/scanner
pkg/scanner/worker.go:7:2: "sync" imported and not used